### PR TITLE
Fix the checking lack for event class type

### DIFF
--- a/src/org/osflash/signals/natives/NativeMappedSignal.as
+++ b/src/org/osflash/signals/natives/NativeMappedSignal.as
@@ -144,10 +144,12 @@ package org.osflash.signals.natives
 				var mappedData:Object = mapEvent(valueObjects[0] as Event);
 				dispatchMappedData(mappedData);
 			} 
+			/*
 			else 
 			{
 				super.dispatch.apply(null, valueObjects);
 			}
+			*/
 		}
 
 		private function areValueObjectValidForMapping(valueObjects:Array):Boolean

--- a/tests/org/osflash/signals/natives/FakeMouseEvent.as
+++ b/tests/org/osflash/signals/natives/FakeMouseEvent.as
@@ -1,0 +1,18 @@
+package org.osflash.signals.natives
+{
+
+import flash.events.Event;
+
+
+public class FakeMouseEvent extends Event
+{
+
+    public static const CLICK:String = "click";
+
+    public function FakeMouseEvent (type:String)
+    {
+        super(type);
+    }
+}
+}
+

--- a/tests/org/osflash/signals/natives/NativeMappedSignalFunctionArgTest.as
+++ b/tests/org/osflash/signals/natives/NativeMappedSignalFunctionArgTest.as
@@ -115,6 +115,17 @@ package org.osflash.signals.natives
 			dispatchTestEvent();
 		}
 		
+		[Test]
+		public function shouldnt_callback_during_checking_of_event_class_type ():void
+		{
+			signalMappingToEventType.add(function (value:String):void
+			{
+				fail("should fail");
+			});
+
+			sprite.dispatchEvent(new FakeMouseEvent(FakeMouseEvent.CLICK));
+		}
+
 		private function checkMappedEventTypeArgument(argument:String):void
 		{
 			assertSame(EventType, argument);


### PR DESCRIPTION
By running the new test case against the code of `v0.8`, will be pass through without any fail or error, but throw up an uncatchable `ArgumentError` additionally.
