### PR TITLE
Adds conditional listeners.

### DIFF
--- a/src/org/osflash/signals/ConditionalSignalBinding.as
+++ b/src/org/osflash/signals/ConditionalSignalBinding.as
@@ -1,0 +1,204 @@
+package org.osflash.signals
+{
+	/**
+	 * The ConditionalSignalBinding class represents a signal binding that
+	 * removes itself if its listener returns a truthy value.
+	 *
+	 * @author Paul Taylor
+	 * @private
+	 */	
+	public class ConditionalSignalBinding implements ISignalBinding
+	{
+		private var _signal:ISignal;
+		private var _enabled:Boolean = true;
+		private var _strict:Boolean = true;
+		private var _listener:Function;
+		private var _priority:int = 0;
+		private var _params:Array;
+		
+		public function ConditionalSignalBinding(listener:Function, signal:ISignal, priority:int = 0)
+		{
+			_listener = listener;
+			_signal = signal;
+			_priority = priority;
+			
+			// Work out what the strict mode is from the signal and set it here. You can change
+			// the value of strict mode on the binding itself at a later date.
+			_strict = signal.strict;
+			
+			verifyListener(listener);
+		}
+		
+		public function execute(valueObjects:Array):void
+		{
+			if(!enabled)
+				return;
+			
+			var value:* = null;
+			
+			// If we have parameters, add them to the valueObject
+			// Note: This could be exensive if we're after the fastest dispatch possible.
+			if(null != _params && _params.length > 0)
+			{
+				// Should there be any checking on the params against the listener?
+				valueObjects = valueObjects.concat(_params);
+			}
+			
+			if(_strict)
+			{
+				// Dispatch as normal
+				const numValueObjects:int = valueObjects.length;
+				if(numValueObjects == 0)
+				{
+					value = listener();
+				}
+				else if(numValueObjects == 1)
+				{
+					value = _listener(valueObjects[0]);
+				}
+				else if(numValueObjects == 2)
+				{
+					value = _listener(valueObjects[0], valueObjects[1]);
+				}
+				else if(numValueObjects == 3)
+				{
+					value = _listener(valueObjects[0], valueObjects[1], valueObjects[2]);
+				}
+				else
+				{
+					value = _listener.apply(null, valueObjects);
+				}
+			}
+			else
+			{
+				// We're going to pass everything in one bulk run so that varargs can be 
+				// passed through to the listeners
+				value = _listener.apply(null, valueObjects);
+			}
+			
+			if(value) remove();
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function get listener():Function
+		{
+			return _listener;
+		}
+		
+		public function set listener(value:Function):void
+		{
+			if(null == value)
+				throw new ArgumentError(
+					'Given listener is null.\nDid you want to set enabled to false instead?');
+			
+			verifyListener(value);
+			_listener = value;
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function get once():Boolean
+		{
+			return false;
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function get priority():int
+		{
+			return _priority;
+		}
+		
+		/**
+		 * Creates and returns the string representation of the current object.
+		 *
+		 * @return The string representation of the current object.
+		 */
+		public function toString():String
+		{
+			return "[SignalBinding listener: " + _listener + ", once: " + once
+				+ ", priority: " + _priority + ", enabled: " + _enabled + "]";
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function get enabled():Boolean
+		{
+			return _enabled;
+		}
+		
+		public function set enabled(value:Boolean):void
+		{
+			_enabled = value;
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function get strict():Boolean
+		{
+			return _strict;
+		}
+		
+		public function set strict(value:Boolean):void
+		{
+			_strict = value;
+			
+			// Check that when we move from one strict mode to another strict mode and verify the 
+			// listener again.
+			verifyListener(listener);
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function get params():Array
+		{
+			return _params;
+		}
+		
+		public function set params(value:Array):void
+		{
+			_params = value;
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function remove():void
+		{
+			_signal.remove(_listener);
+		}
+		
+		protected function verifyListener(listener:Function):void
+		{
+			if(null == listener)
+			{
+				throw new ArgumentError('Given listener is null.');
+			}
+			
+			if(null == _signal)
+			{
+				throw new Error('Internal signal reference has not been set yet.');
+			}
+			
+			const numListenerArgs:int = listener.length;
+			const argumentString:String = (numListenerArgs == 1) ? 'argument' : 'arguments';
+			
+			if(_strict)
+			{
+				if(numListenerArgs < _signal.valueClasses.length)
+				{
+					throw new ArgumentError('Listener has ' + numListenerArgs + ' ' + argumentString
+											+ ' but it needs to be ' +
+											_signal.valueClasses.length + ' to match the signal\'s value classes.');
+				}
+			}
+		}
+	}
+}

--- a/src/org/osflash/signals/DeluxeSignal.as
+++ b/src/org/osflash/signals/DeluxeSignal.as
@@ -63,6 +63,11 @@ package org.osflash.signals
 		{
 			return addWithPriority(listener);
 		}
+		
+		override public function addConditionally(listener:Function):ISignalBinding
+		{
+			return addConditionallyWithPriority(listener);
+		}
 
 		override public function addOnce(listener:Function):ISignalBinding
 		{
@@ -73,6 +78,19 @@ package org.osflash.signals
 		public function addWithPriority(listener:Function, priority:int = 0):ISignalBinding
 		{
 			return registerListenerWithPriority(listener, false, priority);
+		}
+		
+		/** @inheritDoc */
+		public function addConditionallyWithPriority(listener:Function/*<Boolean>*/, priority:int = 0):ISignalBinding
+		{
+			if (registrationPossible(listener, false))
+			{
+				const newBinding:ISignalBinding = new ConditionalSignalBinding(listener, this, priority);
+				bindings = bindings.insertWithPriority(newBinding);
+				return newBinding;
+			}
+			
+			return bindings.find(listener);
 		}
 
 		/** @inheritDoc */

--- a/src/org/osflash/signals/IPrioritySignal.as
+++ b/src/org/osflash/signals/IPrioritySignal.as
@@ -17,7 +17,22 @@ package org.osflash.signals
 		 * @return a ISignalBinding, which contains the Function passed as the parameter
 		 * @see ISignalBinding
 		 */
-		function addWithPriority(listener:Function, priority:int = 0):ISignalBinding
+		function addWithPriority(listener:Function, priority:int = 0):ISignalBinding;
+		
+		/**
+		 * Subscribes a conditional listener for the signal. If the listener
+		 * returns a truthy value (true, > 0, not null), the listener will
+		 * be removed from the signal. If the listener returns a falsey value
+		 * (false, 0, null, or nothing), the listener won't be removed from
+		 * the signal.
+		 * 
+		 * @param	listener A function with an argument list that matches the
+		 * types of arguments dispatched by the signal.
+		 * @return an ISignalBinding, which contains the Function passed as the
+		 * parameter.
+		 * @see ISignalBinding
+		 */
+		function addConditionallyWithPriority(listener:Function/*<Boolean>*/, priority:int = 0):ISignalBinding;
 		
 		/**
 		 * Subscribes a one-time listener for this signal.
@@ -33,6 +48,6 @@ package org.osflash.signals
 		 * @return a ISignalBinding, which contains the Function passed as the parameter
 		 * @see ISignalBinding
 		 */
-		function addOnceWithPriority(listener:Function, priority:int = 0):ISignalBinding
+		function addOnceWithPriority(listener:Function, priority:int = 0):ISignalBinding;
 	}
 }

--- a/src/org/osflash/signals/ISignal.as
+++ b/src/org/osflash/signals/ISignal.as
@@ -32,6 +32,20 @@ package org.osflash.signals
 		function add(listener:Function):ISignalBinding;
 		
 		/**
+		 * Subscribes a conditional listener for this signal. When the listener is invoked,
+		 * the signal will check the return value of the function. If the return
+		 * value is a truthy value (true, > 0, or not null), the listener is
+		 * removed. If the value is falsey (false, 0, null, or nothing), the
+		 * listener is kept around.
+		 * @param	listener A function with arguments that matches the value 
+		 * classes dispatched by the signal and returns true or false indicating
+		 * whether the listener should be removed or not after the invocation.
+		 * If value classes are not specified (e.g. via Signal constructor), dispatch() can be called without arguments.
+		 * @return a ISignalBinding, which contains the function passed as the parameter
+		 */
+		function addConditionally(listener:Function/*<Boolean>*/):ISignalBinding;
+		
+		/**
 		 * Subscribes a one-time listener for this signal.
 		 * The signal will remove the listener automatically the first time it is called,
 		 * after the dispatch to all listeners is complete.
@@ -41,7 +55,7 @@ package org.osflash.signals
 		 * @return a ISignalBinding, which contains the Function passed as the parameter
 		 */
 		function addOnce(listener:Function):ISignalBinding;
-
+		
 		/**
 		 * Dispatches an object to listeners.
 		 * @param	valueObjects	Any number of parameters to send to listeners. Will be type-checked against valueClasses.

--- a/src/org/osflash/signals/PrioritySignal.as
+++ b/src/org/osflash/signals/PrioritySignal.as
@@ -20,6 +20,15 @@ public class PrioritySignal extends Signal implements IPrioritySignal {
     public function addWithPriority( listener:Function, priority:int = 0 ):ISignalBinding {
         return registerListenerWithPriority( listener, false, priority );
     }
+	
+	public function addConditionallyWithPriority(listener:Function/*<Boolean>*/, priority:int = 0):ISignalBinding {
+		if ( registrationPossible( listener, false ) ) {
+			const binding:ISignalBinding = new ConditionalSignalBinding( listener, this, priority );
+			bindings = bindings.insertWithPriority( binding );
+			return binding;
+		}
+		return bindings.find( listener );
+	}
 
     /** @inheritDoc */
     public function addOnceWithPriority( listener:Function, priority:int = 0 ):ISignalBinding {

--- a/src/org/osflash/signals/Signal.as
+++ b/src/org/osflash/signals/Signal.as
@@ -81,6 +81,19 @@ package org.osflash.signals
 		}
 		
 		/** @inheritDoc */
+		public function addConditionally(listener:Function/*<Boolean>*/):ISignalBinding
+		{
+			if (registrationPossible(listener, false))
+			{
+				const newBinding:ISignalBinding = new ConditionalSignalBinding(listener, this);
+				bindings = bindings.prepend(newBinding);
+				return newBinding;
+			}
+			
+			return bindings.find(listener);
+		}
+		
+		/** @inheritDoc */
 		public function addOnce(listener:Function):ISignalBinding
 		{
 			return registerListener(listener, true);

--- a/src/org/osflash/signals/SignalBindingList.as
+++ b/src/org/osflash/signals/SignalBindingList.as
@@ -17,7 +17,7 @@ package org.osflash.signals
 		 *
 		 * <p>A user never has to create a SignalBindingList manually. 
 		 * Use the <code>NIL</code> element to represent an empty list. 
-		 * <code>NIL.prepend(value)</code> would create a list containing <code>value</code>.
+		 * <code>NIL.prepend(value)</code> would create a list containing <code>value</code>.</p>
 		 *
 		 * @param head The first binding in the list.
 		 * @param tail A list containing all bindings except head.

--- a/src/org/osflash/signals/SingleSignal.as
+++ b/src/org/osflash/signals/SingleSignal.as
@@ -26,7 +26,7 @@ package org.osflash.signals
 		
 		protected var _strict:Boolean = true;
 
-		protected var binding:SignalBinding;
+		protected var binding:ISignalBinding;
 		
 		/**
 		 * Creates a Signal instance to dispatch value objects.
@@ -79,6 +79,26 @@ package org.osflash.signals
 		public function add(listener:Function):ISignalBinding
 		{
 			return registerListener(listener);
+		}
+		
+		/** @inheritDoc */
+		public function addConditionally(listener:Function/*<Boolean>*/):ISignalBinding
+		{
+			if(binding != null)
+			{
+				//
+				// If the listener exits previously added, definitely don't add it.
+				//
+				
+				throw new IllegalOperationError('You cannot add or addOnce with a listener already added, remove the current listener first.');
+			}
+			
+			if (!binding || verifyRegistrationOf(listener, false))
+			{
+				return binding = new ConditionalSignalBinding(listener, this);
+			}
+			
+			return binding;
 		}
 		
 		/** @inheritDoc */

--- a/src/org/osflash/signals/natives/NativeSignal.as
+++ b/src/org/osflash/signals/natives/NativeSignal.as
@@ -1,12 +1,13 @@
 package org.osflash.signals.natives
 {
-	import org.osflash.signals.ISignalBinding;
-	import org.osflash.signals.SignalBinding;
-	import org.osflash.signals.SignalBindingList;
-
 	import flash.errors.IllegalOperationError;
 	import flash.events.Event;
 	import flash.events.IEventDispatcher;
+	
+	import org.osflash.signals.ConditionalSignalBinding;
+	import org.osflash.signals.ISignalBinding;
+	import org.osflash.signals.SignalBinding;
+	import org.osflash.signals.SignalBindingList;
 
 	/** 
 	 * Allows the eventClass to be set in MXML, e.g.
@@ -102,6 +103,27 @@ package org.osflash.signals.natives
 		public function addWithPriority(listener:Function, priority:int = 0):ISignalBinding
 		{
 			return registerListenerWithPriority(listener, false, priority);
+		}
+		
+		/** @inheritDoc */
+		public function addConditionally(listener:Function/*<Boolean>*/):ISignalBinding
+		{
+			return addConditionallyWithPriority(listener);
+		}
+		
+		/** @inheritDoc */
+		public function addConditionallyWithPriority(listener:Function/*<Boolean>*/, priority:int = 0):ISignalBinding
+		{
+			if (registrationPossible(listener, false))
+			{
+				const binding:ISignalBinding = new ConditionalSignalBinding(listener, this, priority);
+				if (!bindings.nonEmpty) 
+					target.addEventListener(eventType, onNativeEvent, false, priority);
+				bindings = bindings.insertWithPriority(binding);
+				return binding;
+			}
+			
+			return bindings.find(listener);
 		}
 		
 		/** @inheritDoc */

--- a/tests/org/osflash/signals/ISignalTestBase.as
+++ b/tests/org/osflash/signals/ISignalTestBase.as
@@ -2,7 +2,7 @@ package org.osflash.signals
 {
 	import asunit.asserts.*;
 	import asunit.framework.IAsync;
-
+	
 	import flash.display.Sprite;
 	import flash.events.Event;
 	
@@ -99,6 +99,15 @@ package org.osflash.signals
 		}
 		
 		[Test]
+		public function addConditionally_same_listener_twice_should_only_add_it_once():void
+		{
+			const func:Function = newEmptyHandler();
+			signal.addConditionally(func);
+			signal.addConditionally(func);
+			assertEquals(1, signal.numListeners);
+		}
+		
+		[Test]
 		public function addOnce_same_listener_twice_should_only_add_it_once():void
 		{
 			var func:Function = newEmptyHandler();
@@ -119,7 +128,6 @@ package org.osflash.signals
 			assertTrue(calledB);
 		}
 		
-
 		[Test]
 		public function add_the_same_listener_twice_should_not_throw_error():void
 		{
@@ -237,6 +245,33 @@ package org.osflash.signals
 			}
 			assertEquals("all anonymous listeners removed", 0, signal.numListeners);
 		}		
+		
+		[Test]
+		public function addConditionally_removes_listener_when_listener_returns_true():void
+		{
+			signal.addConditionally(function(e:* = null, ...args):Boolean{return true;});
+			assertEquals("there should be 1 listener", 1, signal.numListeners);
+			dispatchSignal();
+			assertEquals("addConditionally removed listener func when it returned true", 0, signal.numListeners);
+		}
+		
+		[Test]
+		public function addConditionally_does_not_remove_listener_when_listener_returns_false():void
+		{
+			signal.addConditionally(function(e:* = null, ...args):Boolean{return false;});
+			assertEquals("there should be 1 listener", 1, signal.numListeners);
+			dispatchSignal();
+			assertEquals("addConditionally didn't remove the listener func when it returned false", 1, signal.numListeners);
+		}
+		
+		[Test]
+		public function addConditionally_does_not_remove_listener_when_listener_return_type_is_void():void
+		{
+			signal.addConditionally(newEmptyHandler());
+			assertEquals("there should be 1 listener", 1, signal.numListeners);
+			dispatchSignal();
+			assertEquals("addConditionally didn't remove the listener func when its return type is void", 1, signal.numListeners);
+		}
 	
 		[Test]
 		public function add_listener_returns_binding_with_same_listener():void


### PR DESCRIPTION
Adds an "addConditionally" method to ISignal.ISignal#addConditionally adds a "conditional" listener to the signal. If the listener returns a truth-y value (true, > 0, not null) when it's invoked, the listener is removed. If it returns a false-y value (false, 0, null), the listener isn't removed.

For example, this is useful for a "fire-hose" Signal, which can dispatch multiple types.

>   const firehose:ISignal = service.subscribeToSharedEventStream();
>   const typeAHandler:Function = function(obj:*):void{
>       if(!(obj is TypeA)) return;
>       //else do something...
>       firehose.remove(typeAHandler);
>   }
>   signal.add(typeAHandler);
> 
>   service.subscribeToSharedEventStream()
>   .addConditionally(function(obj:*):Boolean{
>       if(!(obj is TypeA)) return false;
>       //else do whatever
>       return true;
>   });
