### PR TITLE
fixes the performance issues of NativeSignalSet

### DIFF
--- a/src/org/osflash/signals/natives/sets/NativeSignalSet.as
+++ b/src/org/osflash/signals/natives/sets/NativeSignalSet.as
@@ -50,7 +50,7 @@ package org.osflash.signals.natives.sets
 	{
 		protected var target:IEventDispatcher;
 		
-		protected const _signals:Dictionary = new Dictionary();
+		protected const _signals:Object = {};
 
 		public function NativeSignalSet(target:IEventDispatcher) 
 		{
@@ -71,13 +71,12 @@ package org.osflash.signals.natives.sets
 		/**
 		 * The current number of listeners for the signal.
 		 */
-		public function get numListeners():int 
+		public function get numListeners():uint 
 		{
-			// TODO : This is horrid, it's very expensive to call this if there is a lot of signals.
-			var count:int = 0;
-			for each (var signal:INativeDispatcher in _signals) 
+			var count:uint;
+			for (var p:String in _signals)
 			{
-				count += signal.numListeners;
+				count += _signals[p].numListeners;
 			}
 			return count;
 		}
@@ -87,11 +86,11 @@ package org.osflash.signals.natives.sets
 		 */
 		public function get signals():Array 
 		{
-			// TODO : This is horrid, it's very expensive to call this if there is a lot of signals.
 			var result:Array = [];
-			for each (var signal:INativeDispatcher in _signals) 
+			var i:uint;
+			for (var p:String in _signals)
 			{
-				result[result.length] = signal;
+				result[i++] = _signals[p];
 			}
 			return result;
 		}
@@ -101,10 +100,10 @@ package org.osflash.signals.natives.sets
 		 */
 		public function removeAll():void 
 		{
-			for each (var signal:INativeDispatcher in _signals) 
+			for (var p:String in _signals)
 			{
-				signal.removeAll();
-				delete _signals[signal.eventType];
+				_signals[p].removeAll();
+				delete _signals[p];
 			}
 		}
 	}


### PR DESCRIPTION
All we have to do is work on implicitly lookups.  

First the Dictionary is not needed as our lookup will be by Strings, so using an Object is more performant as the lookup is expected to be strings (and converted to strings if not).   

Then in the loops the "for each" is not needed as it creates an extra overhead to lookup the objects and try to confirm it's a INativeDispatcher. (the for..in is very fast on Objects)  

And as we know all the elements of the _signals will always be NativeSignals, it is perfectly fine to assume its objects ARE NativeSignals when working with them. The code may look kinda weak but actually implicit access is much faster.  

As a note we could force a cast on line 79 like: count += NativeSignal(_signals[p]).numListeners; but that is not necessary as we know it is a NativeSignal already....  

Well, hope it helps, BUT I haven't run any performance tests. Feel free to reject this if you think it's inappropriate.  

all the best!    
