### PR TITLE
ISlot.applyTo(value:*), ISlot.doesApply(value:*):Boolean, IOnceSignal.removeAll(appliesTo:* = null)

### DIFF
--- a/Maven-Instructions.mdown
+++ b/Maven-Instructions.mdown
@@ -1,0 +1,6 @@
+Maven instructions
+===========
+
+In order to run the unit tests, you must 
+
+	mvn install:install-file -Dfile=./libs/asunit4-alpha.swc -DgroupId=com.asunit -DartifactId=asunit -Dversion=4.0-alpha -Dpackaging=swc

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	
+	<groupId>org.osflash.signals</groupId>
+	<artifactId>as3-signals</artifactId>
+	<name>AS3 Signals</name>
+	<version>0.9-Beta-SNAPSHOT</version>
+	
+	<packaging>swc</packaging>
+
+	<properties>
+		<flex.version>4.5.1.21328</flex.version>
+	</properties>
+	
+	<build>
+        <sourceDirectory>src</sourceDirectory>
+		<testSourceDirectory>tests</testSourceDirectory>
+    
+        <plugins>
+			<plugin>
+				<groupId>org.sonatype.flexmojos</groupId>
+				<artifactId>flexmojos-maven-plugin</artifactId>
+				<version>4.0-RC2</version>
+                <extensions>true</extensions>
+       
+				<configuration>
+					<compilerWarnings>
+	                	<warn-no-constructor>false</warn-no-constructor>
+					</compilerWarnings>
+                </configuration>
+			</plugin>
+		</plugins>
+	</build>
+	
+	<dependencies>
+		<!-- Global flashplayer dependency -->
+		<dependency>
+			<groupId>com.adobe.flex.framework</groupId>
+			<artifactId>playerglobal</artifactId>
+			<version>4.5.1.21328</version>
+			<type>swc</type>
+			<classifier>10.2</classifier>
+		</dependency>
+		
+		<!-- ASUnit dependency, tests only -->
+		<dependency>
+			<groupId>com.asunit</groupId>
+			<artifactId>asunit</artifactId>
+			<version>4.0-alpha</version>
+			<type>swc</type>
+			<scope>test</scope>
+		</dependency>
+		
+		<!-- Flex framework dependency, tests only -->
+		<dependency>
+			<groupId>com.adobe.flex.framework</groupId>
+			<artifactId>flex-framework</artifactId>
+			<version>${flex.version}</version>
+			<type>pom</type>
+			<scope>test</scope>
+		</dependency>
+		
+		
+	</dependencies>
+	
+	<!--- Repository information for flashplayer dependency -->
+	<repositories>
+      <repository>
+         <id>flex-mojos-repository</id>
+         <url>http://repository.sonatype.org/content/groups/flexgroup</url>
+         <releases>
+            <enabled>true</enabled>
+         </releases>
+         <snapshots>
+            <enabled>false</enabled>
+         </snapshots>
+      </repository>
+   </repositories>
+
+   <!-- Repository information for MXMLC and COMPC -->
+   <pluginRepositories>
+      <pluginRepository>
+         <id>flex-mojos-plugin-repository</id>
+         <url>http://repository.sonatype.org/content/groups/flexgroup</url>
+         <releases>
+            <enabled>true</enabled>
+         </releases>
+         <snapshots>
+            <enabled>false</enabled>
+         </snapshots>
+      </pluginRepository>
+   </pluginRepositories>
+
+</project>

--- a/src/org/osflash/signals/IOnceSignal.as
+++ b/src/org/osflash/signals/IOnceSignal.as
@@ -42,7 +42,7 @@ package org.osflash.signals
 		/**
 		 * Unsubscribes all listeners from the signal.
 		 * @param	applyingTo Optional parameter that may be associated with a Slot to remove all listeners associated with a 
-		 * given instance or Class.
+		 * given instance or class type.
 		 */
 		function removeAll(applyingTo:* = null):void
 	}

--- a/src/org/osflash/signals/IOnceSignal.as
+++ b/src/org/osflash/signals/IOnceSignal.as
@@ -41,6 +41,8 @@ package org.osflash.signals
 
 		/**
 		 * Unsubscribes all listeners from the signal.
+		 * @param	applyingTo Optional parameter that may be associated with a Slot to remove all listeners associated with a 
+		 * given instance or Class.
 		 */
 		function removeAll(applyingTo:* = null):void
 	}

--- a/src/org/osflash/signals/IOnceSignal.as
+++ b/src/org/osflash/signals/IOnceSignal.as
@@ -42,6 +42,6 @@ package org.osflash.signals
 		/**
 		 * Unsubscribes all listeners from the signal.
 		 */
-		function removeAll():void
+		function removeAll(applyingTo:* = null):void
 	}
 }

--- a/src/org/osflash/signals/ISlot.as
+++ b/src/org/osflash/signals/ISlot.as
@@ -74,8 +74,14 @@ package org.osflash.signals
 		/**
 		 * Associates this slot with a certain instance or class, allowing the removal of all slots 
 		 * belonging to this object at some future date. 
-		 * @param Either an instance or class definition to associate this slot with.
+		 * @param	value Either an instance or class definition to associate this slot with.
 		 */
-		function appliesTo(value:*):void;
+		function applyTo(value:*):void;
+		
+		/**
+		 * Determines whether or not this slot applies to the supplied instane.
+		 * @param	value Either an instance or class definition to associate this slot with.
+		 */
+		function doesApply(value:*):Boolean;
 	}
 }

--- a/src/org/osflash/signals/ISlot.as
+++ b/src/org/osflash/signals/ISlot.as
@@ -72,8 +72,8 @@ package org.osflash.signals
 		function remove():void;
 		
 		/**
-		 * Associates this slot with a certain instance or class, allowing the removal of all slots 
-		 * belonging to this object at some future date. 
+		 * Associates this slot with a certain instance or a class type, allowing the removal of all slots 
+		 * belonging to this object or class in the future. 
 		 * @param	value Either an instance or class definition to associate this slot with.
 		 */
 		function applyTo(value:*):void;

--- a/src/org/osflash/signals/ISlot.as
+++ b/src/org/osflash/signals/ISlot.as
@@ -70,5 +70,12 @@ package org.osflash.signals
 		 * Removes the slot from its signal.
 		 */
 		function remove():void;
+		
+		/**
+		 * Associates this slot with a certain instance or class, allowing the removal of all slots 
+		 * belonging to this object at some future date. 
+		 * @param Either an instance or class definition to associate this slot with.
+		 */
+		function appliesTo(value:*):void;
 	}
 }

--- a/src/org/osflash/signals/MonoSignal.as
+++ b/src/org/osflash/signals/MonoSignal.as
@@ -98,7 +98,7 @@ package org.osflash.signals
 		{
 			if (applyingTo)
 			{
-				//todo	
+				if (slot && slot.doesApply(applyingTo)) slot.remove();
 			}
 			else if (slot) slot.remove();
 		}

--- a/src/org/osflash/signals/MonoSignal.as
+++ b/src/org/osflash/signals/MonoSignal.as
@@ -94,9 +94,13 @@ package org.osflash.signals
 		}
 		
 		/** @inheritDoc */
-		public function removeAll():void
+		public function removeAll(applyingTo:* = null):void
 		{
-			if (slot) slot.remove();
+			if (applyingTo)
+			{
+				//todo	
+			}
+			else if (slot) slot.remove();
 		}
 		
 		/**

--- a/src/org/osflash/signals/OnceSignal.as
+++ b/src/org/osflash/signals/OnceSignal.as
@@ -87,9 +87,21 @@ package org.osflash.signals
 		}
 		
 		/** @inheritDoc */
-		public function removeAll():void
+		public function removeAll(applyingTo:* = null):void
 		{
-			slots = SlotList.NIL;
+			if (applyingTo)
+			{
+				//todo:
+				
+				//find all slots for the applyingTo prop
+					//const found:SlotList = slots.findAll(applyingTo)
+				//remove that list
+					//slots.filterOut(found)
+			}
+			else
+			{
+				slots = SlotList.NIL;
+			}
 		}
 		
 		/**

--- a/src/org/osflash/signals/OnceSignal.as
+++ b/src/org/osflash/signals/OnceSignal.as
@@ -91,12 +91,7 @@ package org.osflash.signals
 		{
 			if (applyingTo)
 			{
-				//todo:
-				
-				//find all slots for the applyingTo prop
-					//const found:SlotList = slots.findAll(applyingTo)
-				//remove that list
-					//slots.filterOut(found)
+				slots = slots.filterNotAppliesTo(applyingTo);	
 			}
 			else
 			{

--- a/src/org/osflash/signals/Slot.as
+++ b/src/org/osflash/signals/Slot.as
@@ -171,9 +171,17 @@ package org.osflash.signals
 		/**
 		 * @inheritDoc
 		 */
-		public function appliesTo(value:*):void
+		public function applyTo(value:*):void
 		{
 			_appliesTo = value;
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function doesApply(value:*):Boolean
+		{
+			return value && (_appliesTo == value || (value is Class && _appliesTo is value) || (_appliesTo is Class && value is _appliesTo));
 		}
 
 		protected function verifyListener(listener:Function): void

--- a/src/org/osflash/signals/Slot.as
+++ b/src/org/osflash/signals/Slot.as
@@ -14,6 +14,7 @@ package org.osflash.signals
 		protected var _once:Boolean = false;
 		protected var _priority:int = 0;
 		protected var _params:Array;
+		protected var _appliesTo:*;
 		
 		/**
 		 * Creates and returns a new Slot object.
@@ -165,6 +166,14 @@ package org.osflash.signals
 		public function remove():void
 		{
 			_signal.remove(_listener);
+		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		public function appliesTo(value:*):void
+		{
+			_appliesTo = value;
 		}
 
 		protected function verifyListener(listener:Function): void

--- a/src/org/osflash/signals/SlotList.as
+++ b/src/org/osflash/signals/SlotList.as
@@ -192,6 +192,49 @@ package org.osflash.signals
 			// The listener was not found so this list is unchanged.
 			return this;
 		}
+		
+		/**
+		 * Returns the slots in this list that do not apply the supplied applier.
+		 * 
+		 * @param	value Object instance or class that a slot may be applied to.
+		 */
+		public function filterNotAppliesTo(value:*):SlotList
+		{
+			if (!nonEmpty) return NIL;
+				
+			var current:SlotList = this;
+			var prev:SlotList = null;
+			
+			while (current.nonEmpty)
+			{
+				if (current.head.doesApply(value))
+				{
+					if (prev) //has previous list
+					{
+						//skip over current.head
+						prev.tail = current.tail;
+						current = current.tail;
+					}
+					else 
+					{
+						//return NIL if last in list
+						if (current.length == 1) return NIL;
+						
+						//shift to next in list
+						current.head = current.tail.head;
+						current.tail = current.tail.tail;
+					}
+				}
+				else
+				{
+					//continue through the list
+					prev = current;
+					current = current.tail;
+				}
+			}
+			
+			return this;
+		}
 
 		/**
 		 * Determines whether the supplied listener Function is contained within this list

--- a/src/org/osflash/signals/SlotList.as
+++ b/src/org/osflash/signals/SlotList.as
@@ -273,6 +273,40 @@ package org.osflash.signals
 			return null;
 		}
 
+		/**
+		 * Creates and returns a new SlotList of all slots that apply to given applicator.
+		 * 
+		 * @param	value Object instance or Class that a slot may be applied to.
+		 */
+		public function findAppliesTo(value:*):SlotList
+		{
+			if (!nonEmpty) return NIL;
+			
+			var current:SlotList = this;
+			var output:SlotList; 
+			var outputCursor:SlotList;
+			
+			while (current.nonEmpty)
+			{
+				if (current.head.doesApply(value))
+				{
+					if (output)
+					{
+						outputCursor.tail = new SlotList(current.head);
+						outputCursor = outputCursor.tail;
+					}
+					else
+					{
+						output = outputCursor = new SlotList(current.head);
+					}
+					
+				}
+				current = current.tail;
+			}
+			
+			return output || NIL;
+		}
+		
 		public function toString():String
 		{
 			var buffer:String = '';

--- a/src/org/osflash/signals/natives/NativeRelaySignal.as
+++ b/src/org/osflash/signals/natives/NativeRelaySignal.as
@@ -128,10 +128,14 @@ package org.osflash.signals.natives
 		/**
 		 * @inheritDoc
 		 */
-		override public function removeAll():void
+		override public function removeAll(applyingTo:* = null):void
 		{
-			if (target) target.removeEventListener(eventType, onNativeEvent);
-			super.removeAll();
+			if (applyingTo)
+			{
+				//todo	
+			}
+			else if (target) target.removeEventListener(eventType, onNativeEvent);
+			super.removeAll(applyingTo);
 		}
 
 		/**

--- a/src/org/osflash/signals/natives/NativeRelaySignal.as
+++ b/src/org/osflash/signals/natives/NativeRelaySignal.as
@@ -130,12 +130,8 @@ package org.osflash.signals.natives
 		 */
 		override public function removeAll(applyingTo:* = null):void
 		{
-			if (applyingTo)
-			{
-				//todo	
-			}
-			else if (target) target.removeEventListener(eventType, onNativeEvent);
 			super.removeAll(applyingTo);
+			if (!slots.nonEmpty && target) target.removeEventListener(eventType, onNativeEvent);
 		}
 
 		/**

--- a/src/org/osflash/signals/natives/NativeSignal.as
+++ b/src/org/osflash/signals/natives/NativeSignal.as
@@ -132,15 +132,22 @@ package org.osflash.signals.natives
 		}
 		
 		/** @inheritDoc */
-		public function removeAll():void
+		public function removeAll(applyingTo:* = null):void
 		{
-			var slotsToProcess:SlotList = slots;
-			while (slotsToProcess.nonEmpty)
+			if (applyingTo)
 			{
-				target.removeEventListener(_eventType, slotsToProcess.head.execute1);
-				slotsToProcess = slotsToProcess.tail;
+				//todo...
 			}
-			slots = SlotList.NIL;
+			else
+			{
+				var slotsToProcess:SlotList = slots;
+				while (slotsToProcess.nonEmpty)
+				{
+					target.removeEventListener(_eventType, slotsToProcess.head.execute1);
+					slotsToProcess = slotsToProcess.tail;
+				}
+				slots = SlotList.NIL;
+			}
 		}
 
 		/**

--- a/src/org/osflash/signals/natives/NativeSignal.as
+++ b/src/org/osflash/signals/natives/NativeSignal.as
@@ -134,20 +134,24 @@ package org.osflash.signals.natives
 		/** @inheritDoc */
 		public function removeAll(applyingTo:* = null):void
 		{
+			var slotsToProcess:SlotList;
+			
 			if (applyingTo)
 			{
-				//todo...
+				slotsToProcess = slots.findAppliesTo(applyingTo);
 			}
 			else
 			{
-				var slotsToProcess:SlotList = slots;
-				while (slotsToProcess.nonEmpty)
-				{
-					target.removeEventListener(_eventType, slotsToProcess.head.execute1);
-					slotsToProcess = slotsToProcess.tail;
-				}
-				slots = SlotList.NIL;
+				slotsToProcess = slots;
 			}
+			
+			while (slotsToProcess.nonEmpty)
+			{
+				target.removeEventListener(_eventType, slotsToProcess.head.execute1);
+				slotsToProcess = slotsToProcess.tail;
+			}
+			
+			slots = (applyingTo) ? slots.filterNotAppliesTo(applyingTo) : SlotList.NIL;
 		}
 
 		/**

--- a/src/org/osflash/signals/natives/sets/NativeSignalSet.as
+++ b/src/org/osflash/signals/natives/sets/NativeSignalSet.as
@@ -99,12 +99,13 @@ package org.osflash.signals.natives.sets
 		/**
 		 * Unsubscribes all listeners from all signals in the set.
 		 */
-		public function removeAll():void 
+		public function removeAll(applyingTo:* = null):void 
 		{
 			for each (var signal:INativeDispatcher in _signals) 
 			{
-				signal.removeAll();
-				delete _signals[signal.eventType];
+				signal.removeAll(applyingTo);
+				if (signal.numListeners == 0)
+					delete _signals[signal.eventType];
 			}
 		}
 	}

--- a/tests/org/osflash/signals/ISignalTestBase.as
+++ b/tests/org/osflash/signals/ISignalTestBase.as
@@ -2,7 +2,7 @@ package org.osflash.signals
 {
 	import asunit.asserts.*;
 	import asunit.framework.IAsync;
-
+	
 	import flash.events.Event;
 	
 	public class ISignalTestBase
@@ -218,6 +218,46 @@ package org.osflash.signals
 			var listener:Function = newEmptyHandler();
 			var slot:ISlot = signal.add(listener);
 			assertSame(slot, signal.remove(listener));
+		}
+		
+		[Test]
+		public function removeAll_appliedTo_3_slots_removes_3():void
+		{
+			signal.add(newEmptyHandler()).applyTo(this);
+			signal.add(newEmptyHandler()).applyTo(this);
+			signal.addOnce(newEmptyHandler()).applyTo(this);
+			signal.removeAll(this);
+			assertEquals(0, signal.numListeners);
+		}
+		
+		[Test]
+		public function removeAll_appliedTo_no_slots_removes_none():void
+		{
+			signal.add(newEmptyHandler()).applyTo({});
+			signal.addOnce(newEmptyHandler());
+			signal.add(newEmptyHandler());
+			signal.removeAll(this);
+			assertEquals(3, signal.numListeners);
+		}
+		
+		[Test]
+		public function removeAll_appliedTo_2nd_slot_removes_1_only():void
+		{
+			signal.add(newEmptyHandler());
+			signal.add(newEmptyHandler()).applyTo(this);
+			signal.add(newEmptyHandler());
+			signal.removeAll(this);
+			assertEquals(2, signal.numListeners);
+		}
+		
+		[Test]
+		public function removeAll_appliedTo_1st_and_3rd_slots_removes_2_only():void
+		{
+			signal.add(newEmptyHandler()).applyTo(this);
+			signal.add(newEmptyHandler());
+			signal.add(newEmptyHandler()).applyTo(this);
+			signal.removeAll(this);
+			assertEquals(1, signal.numListeners);
 		}
 		
 		protected function dispatchSignal():void 

--- a/tests/org/osflash/signals/ISlotTestBase.as
+++ b/tests/org/osflash/signals/ISlotTestBase.as
@@ -7,12 +7,12 @@ package org.osflash.signals
 	import asunit.asserts.assertTrue;
 	import asunit.asserts.fail;
 	import asunit.framework.IAsync;
-
-	import org.osflash.signals.events.GenericEvent;
-
+	
 	import flash.display.Sprite;
 	import flash.events.Event;
 	import flash.events.MouseEvent;
+	
+	import org.osflash.signals.events.GenericEvent;
 	/**
 	 * @author Simon Richardson - simon@ustwo.co.uk
 	 */
@@ -365,6 +365,52 @@ package org.osflash.signals
 			
 			var slot:ISlot = signal.addOnce(newEmptyHandler());
 			slot.execute([1, 2, 3, 4, 5, 6, 7, 8, 9]); 
+		}
+		
+		[Test]
+		public function applyTo_instance_correctly_doesApplyTo_instance():void
+		{
+			var instance:Object = {};
+			var listener:Function = newEmptyHandler();
+			var slot:ISlot = signal.add(newEmptyHandler);
+			
+			slot.applyTo(instance);
+			assertTrue(slot.doesApply(instance));
+			assertFalse(slot.doesApply(this));
+		}
+		
+		[Test]
+		public function applyTo_instance_correctly_doesApplyTo_class():void
+		{
+			var listener:Function = newEmptyHandler();
+			var slot:ISlot = signal.add(newEmptyHandler);
+			
+			slot.applyTo(this);
+			assertTrue(slot.doesApply(ISlotTestBase));
+			assertFalse(slot.doesApply(ISlot));
+			assertFalse(slot.doesApply({}));
+		}
+		
+		[Test]
+		public function applyTo_class_correctly_doesApplyTo_instance():void
+		{
+			var listener:Function = newEmptyHandler();
+			var slot:ISlot = signal.add(newEmptyHandler);
+			
+			slot.applyTo(ISlotTestBase);
+			assertTrue(slot.doesApply(this));
+			assertFalse(slot.doesApply({}));
+		}
+		
+		[Test]
+		public function applyTo_class_correctly_doesApplyTo_class():void
+		{
+			var listener:Function = newEmptyHandler();
+			var slot:ISlot = signal.add(newEmptyHandler);
+			
+			slot.applyTo(ISlotTestBase);
+			assertTrue(slot.doesApply(ISlotTestBase));
+			assertFalse(slot.doesApply(ISlot));
 		}
 		
 		[Test]

--- a/tests/org/osflash/signals/MonoSignalTest.as
+++ b/tests/org/osflash/signals/MonoSignalTest.as
@@ -305,5 +305,21 @@ package org.osflash.signals
 			
 			signal.dispatch();
 		}
+		
+		[Test]
+		public function removeAll_doesnt_remove_when_not_applied():void
+		{
+			signal.add(newEmptyHandler());
+			signal.removeAll(this);
+			assertEquals(1, signal.numListeners);
+		}
+		
+		[Test]
+		public function removeAll_removes_listener_when_applied():void
+		{
+			signal.add(newEmptyHandler()).applyTo(this);
+			signal.removeAll(this);
+			assertEquals(0, signal.numListeners);
+		}
 	}
 }

--- a/tests/org/osflash/signals/SlotListTest.as
+++ b/tests/org/osflash/signals/SlotListTest.as
@@ -228,5 +228,120 @@ package org.osflash.signals
 			assertEquals(2, newList.length);
 		}
 		
+		[Test]
+		public function filterNotAppliesTo_head_slot_from_list_of_1_yields_empty_list():void
+		{
+			slotA.applyTo(this);
+			const newList:SlotList = listOfA.filterNotAppliesTo(this);
+			assertEquals(SlotList.NIL, newList);
+		}
+			
+		[Test]
+		public function filterNotAppliesTo_1st_slot_from_list_of_2_yields_list_of_2nd_listener():void
+		{
+			slotA.applyTo(this);
+			const newList:SlotList = listOfAB.filterNotAppliesTo(this);
+			assertSame(slotB, newList.head);
+			assertEquals(1, newList.length);
+		}
+		
+		[Test]
+		public function filterNotAppliesTo_both_slots_from_list_of_2_yields_empty_list():void
+		{
+			slotA.applyTo(this);
+			slotB.applyTo(this);
+			const newList:SlotList = listOfAB.filterNotAppliesTo(this);
+			assertEquals(SlotList.NIL, newList);
+		}
+		
+		[Test]
+		public function filterNotAppliesTo_2nd_slot_from_list_of_3_yields_list_of_1st_and_3rd_slots():void
+		{
+			slotB.applyTo(this);
+			const newList:SlotList = listOfABC.filterNotAppliesTo(this);
+			assertEquals(2, newList.length);
+			assertSame(slotA, newList.head);
+			assertSame(slotC, newList.tail.head);
+		}
+		
+		[Test]
+		public function filterNotAppliesTo_unbound_instance_from_list_of_3_yields_list_of_3_slots():void
+		{
+			slotB.applyTo(this);
+			const newList:SlotList = listOfABC.filterNotAppliesTo({});
+			assertEquals(3, newList.length);
+			assertSame(slotA, newList.head);
+			assertSame(slotB, newList.tail.head);
+			assertSame(slotC, newList.tail.tail.head);
+		}
+		
+		[Test]
+		public function filterNotAppliesTo_3rd_slot_from_list_of_3_yields_list_of_1st_and_2nd_slots():void
+		{
+			slotC.applyTo(this);
+			const newList:SlotList = listOfABC.filterNotAppliesTo(this);
+			assertEquals(2, newList.length);
+			assertSame(slotA, newList.head);
+			assertSame(slotB, newList.tail.head);
+		}
+		
+		[Test]
+		public function findAppliesTo_no_slot_from_list_of_3_yields_empty_list():void
+		{
+			const newList:SlotList = listOfABC.findAppliesTo(this);
+			assertSame(SlotList.NIL, newList);
+		}
+		
+		[Test]
+		public function findAppliesTo_1st_slot_from_list_of_3_yields_list_of_1st_slot():void
+		{
+			slotA.applyTo(this);
+			const newList:SlotList = listOfABC.findAppliesTo(this);
+			assertSame(slotA, newList.head);
+			assertEquals(1, newList.length);
+		}
+		
+		[Test]
+		public function findAppliesTo_1st_and_3rd_slots_from_list_of_3_yields_list_of_1st_and_3rd_slots():void
+		{
+			slotA.applyTo(this);
+			slotC.applyTo(this);
+			const newList:SlotList = listOfABC.findAppliesTo(this);
+			assertSame(slotA, newList.head);
+			assertSame(slotC, newList.tail.head);
+			assertEquals(2, newList.length);
+		}
+	
+		[Test]
+		public function findAppliesTo_3rd_slot_from_list_of_3_yields_list_of_3rd_slots():void
+		{
+			slotC.applyTo(this);
+			const newList:SlotList = listOfABC.findAppliesTo(this);
+			assertSame(slotC, newList.head);
+			assertEquals(1, newList.length);
+		}
+		
+		[Test]
+		public function findAppliesTo_2nd_slot_from_list_of_3_yields_list_of_2nd_slot():void
+		{
+			slotB.applyTo(this);
+			const newList:SlotList = listOfABC.findAppliesTo(this);
+			assertSame(slotB, newList.head);
+			assertEquals(1, newList.length);
+		}
+		
+		[Test]
+		public function findAppliesTo_all_slots_from_list_of_3_yields_list_of_3_slots():void
+		{
+			slotA.applyTo(this);
+			slotB.applyTo(this);
+			slotC.applyTo(this);
+			const newList:SlotList = listOfABC.findAppliesTo(this);
+			assertSame(slotA, newList.head);
+			assertSame(slotB, newList.tail.head);
+			assertSame(slotC, newList.tail.tail.head);
+			assertEquals(3, newList.length);
+		}
+		
 	}
 }

--- a/tests/org/osflash/signals/natives/INativeDispatcherTestBase.as
+++ b/tests/org/osflash/signals/natives/INativeDispatcherTestBase.as
@@ -306,5 +306,26 @@ package org.osflash.signals.natives
 			assertEquals(numListenersBefore, clicked.numListeners);
 		}	
 	
+		//applyTo checking
+		[Test]
+		public function applyTo_then_removeAll_removes_all():void
+		{
+			clicked.add(emptyMouseHandler).applyTo(this);
+			clicked.add(newEmptyHandler()).applyTo(this);
+			clicked.removeAll(this);
+			verifyNoListeners();
+		}
+		
+		[Test]
+		public function applyTo_then_removeAll_only_removes_applied():void
+		{
+			clicked.add(emptyMouseHandler).applyTo(this);
+			clicked.add(newEmptyHandler());
+			clicked.removeAll(this);
+			assertEquals(1, clicked.numListeners);
+			assertTrue(sprite.hasEventListener('click'));
+			clicked.removeAll();
+			verifyNoListeners();
+		}
 	}
 }

--- a/tests/org/osflash/signals/natives/sets/NativeSignalSetTest.as
+++ b/tests/org/osflash/signals/natives/sets/NativeSignalSetTest.as
@@ -1,12 +1,15 @@
 package org.osflash.signals.natives.sets
 {
-	import flash.events.Event;
-	import org.osflash.signals.natives.NativeSignal;
 	import asunit.asserts.assertNotNull;
 	import asunit.asserts.assertTrue;
 	import asunit.framework.IAsync;
-
+	
 	import flash.display.Sprite;
+	import flash.events.Event;
+	
+	import org.osflash.signals.ISignal;
+	import org.osflash.signals.natives.NativeSignal;
+
 	/**
 	 * @author Simon Richardson - me@simonrichardson.info
 	 */
@@ -253,5 +256,19 @@ package org.osflash.signals.natives.sets
 		}
 		
 		//////
+		
+		[Test]
+		public function numListeners_should_be_one_after_removeAll_with_appliedTo_all_else():void
+		{
+			const signal:NativeSignal = signalSet.getNativeSignal(Event.CHANGE);
+			
+			signal.add(newEmptyHandler()).applyTo(this);
+			signal.add(newEmptyHandler());
+			signal.add(newEmptyHandler()).applyTo(this);
+			
+			signalSet.removeAll(this);
+			
+			assertTrue('Number of listeners should be 1.', signalSet.numListeners == 1);
+		}
 	}
 }


### PR DESCRIPTION
Additions:
- `ISlot.applyTo(value:*):void`
- `ISlot.doesApply(value:*):Boolean`
- `IOnceSignal.removeAll(appliesTo:* = null):void`
- `SlotListener.filterNotAppliesTo(value:*):SlotList`
- `SlotListener.findNotAppliesTo(value:*):SlotList`

This backwards compatible addition allows a slot to be applied to an instance or class. The removeAll() method allows for an optional parameter which will then removeAll slots that applyTo the given parameter, if any. 

Essentially, this allows us to asynchronously clean up after a class or instance without affecting any listeners from other classes and without having to define our closures or locally define the slots. 

```
public class A
{
     [Inject]
     public var service:IService;

     public function init():void
     {
          service.start().add(function(... args):void {}).applyTo(this);
          service.send("something").add(function(... args):void { ... }).applyTo(this);
     }

     public function dispose():void
     {
          service.removeAll(this);
     }
}
```

The reason being is that Signals may be reused across instances and classes. For example, a service that is managed by an IOC container may cache signal calls, or a model may use signals to notify of a change. When the signal is shared across various types we don't want to "removeAll()" lest we remove functional code in other classes (that may well have been written by other developers).   
